### PR TITLE
Changes the CentroidList implementation to not use pointers.

### DIFF
--- a/centroid.go
+++ b/centroid.go
@@ -19,7 +19,6 @@ func (e Error) Error() string {
 type Centroid struct {
 	Mean   float64
 	Weight float64
-	index  int
 }
 
 func (c *Centroid) String() string {
@@ -27,7 +26,7 @@ func (c *Centroid) String() string {
 }
 
 // Add averages the two centroids together and update this centroid
-func (c *Centroid) Add(r *Centroid) error {
+func (c *Centroid) Add(r Centroid) error {
 	if r.Weight < 0 {
 		return ErrWeightLessThanZero
 	}
@@ -41,65 +40,20 @@ func (c *Centroid) Add(r *Centroid) error {
 	return nil
 }
 
-// CentroidList is a priority queue sorted by the Mean of the centroid, descending.
-type CentroidList struct {
-	Centroids []*Centroid
-	index     int
-}
-
-// Weight returns the summed weight of all centroids
-func (l *CentroidList) Weight() (w float64) {
-	for i := range l.Centroids {
-		w += l.Centroids[i].Weight
-	}
-	return w
-}
-func (l *CentroidList) WeightAt(i int) float64 {
-	return l.Centroids[i].Weight
-}
-func (l *CentroidList) MeanAt(i int) float64 {
-	return l.Centroids[i].Mean
-}
+// CentroidList is sorted by the Mean of the centroid, ascending.
+type CentroidList []Centroid
 
 func (l *CentroidList) Clear() {
-	l.Centroids = l.Centroids[0:0]
+	*l = (*l)[0:0]
 }
 
-func (l *CentroidList) Len() int { return len(l.Centroids) }
-
-func (l *CentroidList) Less(i, j int) bool {
-	return l.Centroids[i].Mean < l.Centroids[j].Mean
-}
-
-func (l *CentroidList) Swap(i, j int) {
-	l.Centroids[i], l.Centroids[j] = l.Centroids[j], l.Centroids[i]
-	l.Centroids[i].index = i
-	l.Centroids[j].index = j
-}
-
-// Push pushes the centroid x onto the CentroidList priority queue
-func (l *CentroidList) Push(x interface{}) {
-	n := len(l.Centroids)
-	item := x.(*Centroid)
-	item.index = n
-	l.Centroids = append(l.Centroids, item)
-}
-
-// Pop removes the centroid with the maximum mean from the priority queue
-func (l *CentroidList) Pop() interface{} {
-	old := l.Centroids
-	n := len(old)
-	item := old[n-1]
-	item.index = -1
-	l.Centroids = old[0 : n-1]
-	return item
-}
+func (l CentroidList) Len() int           { return len(l) }
+func (l CentroidList) Less(i, j int) bool { return l[i].Mean < l[j].Mean }
+func (l CentroidList) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
 
 // NewCentroidList creates a priority queue for the centroids
-func NewCentroidList(centroids []*Centroid) *CentroidList {
-	l := &CentroidList{
-		Centroids: centroids,
-	}
+func NewCentroidList(centroids []Centroid) CentroidList {
+	l := CentroidList(centroids)
 	sort.Sort(l)
 	return l
 }

--- a/centroid_test.go
+++ b/centroid_test.go
@@ -4,14 +4,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/tdigest"
 )
-
-var CmpOptions = cmp.Options{
-	cmpopts.IgnoreUnexported(tdigest.Centroid{}),
-	cmpopts.IgnoreUnexported(tdigest.CentroidList{}),
-}
 
 func TestCentroid_Add(t *testing.T) {
 	tests := []struct {
@@ -64,13 +58,13 @@ func TestCentroid_Add(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &tt.c
-			if err := c.Add(&tt.r); (err != nil) != tt.wantErr {
+			if err := c.Add(tt.r); (err != nil) != tt.wantErr {
 				t.Errorf("Centroid.Add() error = %v, wantErr %v", err, tt.wantErr)
 			} else if tt.wantErr && err.Error() != tt.errStr {
 				t.Errorf("Centroid.Add() error.Error() = %s, errStr %v", err.Error(), tt.errStr)
 			}
-			if !cmp.Equal(tt.c, tt.want, CmpOptions...) {
-				t.Errorf("unexprected centroid -want/+got\n%s", cmp.Diff(tt.want, tt.c, CmpOptions...))
+			if !cmp.Equal(tt.c, tt.want) {
+				t.Errorf("unexprected centroid -want/+got\n%s", cmp.Diff(tt.want, tt.c))
 			}
 		})
 	}
@@ -79,86 +73,49 @@ func TestCentroid_Add(t *testing.T) {
 func TestNewCentroidList(t *testing.T) {
 	tests := []struct {
 		name      string
-		centroids []*tdigest.Centroid
-		want      *tdigest.CentroidList
+		centroids []tdigest.Centroid
+		want      tdigest.CentroidList
 	}{
 		{
 			name: "empty list",
-			want: &tdigest.CentroidList{},
 		},
 		{
 			name: "priority should be by mean ascending",
-			centroids: []*tdigest.Centroid{
-				&tdigest.Centroid{
+			centroids: []tdigest.Centroid{
+				{
 					Mean: 2.0,
 				},
-				&tdigest.Centroid{
+				{
 					Mean: 1.0,
 				},
 			},
-			want: &tdigest.CentroidList{
-				Centroids: []*tdigest.Centroid{
-					&tdigest.Centroid{
-						Mean: 1.0,
-					},
-					&tdigest.Centroid{
-						Mean: 2.0,
-					},
+			want: tdigest.CentroidList{
+				{
+					Mean: 1.0,
+				},
+				{
+					Mean: 2.0,
 				},
 			},
 		},
 		{
 			name: "single element should be identity",
-			centroids: []*tdigest.Centroid{
-				&tdigest.Centroid{
+			centroids: []tdigest.Centroid{
+				{
 					Mean: 1.0,
 				},
 			},
-			want: &tdigest.CentroidList{
-				Centroids: []*tdigest.Centroid{
-					&tdigest.Centroid{
-						Mean: 1.0,
-					},
+			want: tdigest.CentroidList{
+				{
+					Mean: 1.0,
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tdigest.NewCentroidList(tt.centroids); !cmp.Equal(tt.want, got, CmpOptions...) {
-				t.Errorf("NewCentroidList() = -want/+got %s", cmp.Diff(tt.want, got, CmpOptions...))
-			}
-		})
-	}
-}
-
-func TestCentroid_Weight(t *testing.T) {
-	tests := []struct {
-		name string
-		list *tdigest.CentroidList
-		want float64
-	}{
-		{
-			name: "should be the sum total of all centroid weights",
-			list: &tdigest.CentroidList{
-				Centroids: []*tdigest.Centroid{
-					&tdigest.Centroid{
-						Mean:   2.0,
-						Weight: 2.0,
-					},
-					&tdigest.Centroid{
-						Mean:   1.0,
-						Weight: 1.0,
-					},
-				},
-			},
-			want: 3.0,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.list.Weight(); !cmp.Equal(tt.want, got, CmpOptions...) {
-				t.Errorf("CentroidList.Weight() = -want/+got %s", cmp.Diff(tt.want, got, CmpOptions...))
+			if got := tdigest.NewCentroidList(tt.centroids); !cmp.Equal(tt.want, got) {
+				t.Errorf("NewCentroidList() = -want/+got %s", cmp.Diff(tt.want, got))
 			}
 		})
 	}

--- a/tdigest.go
+++ b/tdigest.go
@@ -28,8 +28,8 @@ func NewWithCompression(c float64) *TDigest {
 	}
 	t.maxProcessed = processedSize(0, t.Compression)
 	t.maxUnprocessed = unprocessedSize(0, t.Compression)
-	t.processed.Centroids = make([]*Centroid, 0, t.maxProcessed)
-	t.unprocessed.Centroids = make([]*Centroid, 0, t.maxUnprocessed+1)
+	t.processed = make([]Centroid, 0, t.maxProcessed)
+	t.unprocessed = make([]Centroid, 0, t.maxUnprocessed+1)
 	t.min = math.MaxFloat64
 	t.max = -math.MaxFloat64
 	return t
@@ -39,10 +39,10 @@ func (t *TDigest) Add(x, w float64) {
 	if math.IsNaN(x) {
 		return
 	}
-	t.AddCentroid(&Centroid{Mean: x, Weight: w})
+	t.AddCentroid(Centroid{Mean: x, Weight: w})
 }
 
-func (t *TDigest) AddCentroidList(c *CentroidList) {
+func (t *TDigest) AddCentroidList(c CentroidList) {
 	l := c.Len()
 	for i := 0; i < l; i++ {
 		diff := l - i
@@ -52,14 +52,14 @@ func (t *TDigest) AddCentroidList(c *CentroidList) {
 			mid = i + room
 		}
 		for i < mid {
-			t.AddCentroid(c.Centroids[i])
+			t.AddCentroid(c[i])
 			i++
 		}
 	}
 }
 
-func (t *TDigest) AddCentroid(c *Centroid) {
-	t.unprocessed.Centroids = append(t.unprocessed.Centroids, c)
+func (t *TDigest) AddCentroid(c Centroid) {
+	t.unprocessed = append(t.unprocessed, c)
 	t.unprocessedWeight += c.Weight
 
 	if t.processed.Len() > t.maxProcessed ||
@@ -73,31 +73,31 @@ func (t *TDigest) process() {
 		t.processed.Len() > t.maxProcessed {
 
 		// Append all processed centroids to the unprocessed list and sort
-		t.unprocessed.Centroids = append(t.unprocessed.Centroids, t.processed.Centroids...)
+		t.unprocessed = append(t.unprocessed, t.processed...)
 		sort.Sort(&t.unprocessed)
 
 		// Reset processed list with first centroid
 		t.processed.Clear()
-		t.processed.Centroids = append(t.processed.Centroids, t.unprocessed.Centroids[0])
+		t.processed = append(t.processed, t.unprocessed[0])
 
 		t.processedWeight += t.unprocessedWeight
 		t.unprocessedWeight = 0
-		soFar := t.unprocessed.WeightAt(0)
+		soFar := t.unprocessed[0].Weight
 		limit := t.processedWeight * t.integratedQ(1.0)
-		for _, centroid := range t.unprocessed.Centroids[1:] {
+		for _, centroid := range t.unprocessed[1:] {
 			projected := soFar + centroid.Weight
 			if projected <= limit {
 				soFar = projected
-				t.processed.Centroids[t.processed.Len()-1].Add(centroid)
+				(&t.processed[t.processed.Len()-1]).Add(centroid)
 			} else {
 				k1 := t.integratedLocation(soFar / t.processedWeight)
 				limit = t.processedWeight * t.integratedQ(k1+1.0)
 				soFar += centroid.Weight
-				t.processed.Centroids = append(t.processed.Centroids, centroid)
+				t.processed = append(t.processed, centroid)
 			}
 		}
-		t.min = math.Min(t.min, t.processed.MeanAt(0))
-		t.max = math.Max(t.max, t.processed.MeanAt(t.processed.Len()-1))
+		t.min = math.Min(t.min, t.processed[0].Mean)
+		t.max = math.Max(t.max, t.processed[t.processed.Len()-1].Mean)
 		t.updateCumulative()
 		t.unprocessed.Clear()
 	}
@@ -106,7 +106,7 @@ func (t *TDigest) process() {
 func (t *TDigest) updateCumulative() {
 	t.cumulative = make([]float64, t.processed.Len()+1)
 	prev := 0.0
-	for i, centroid := range t.processed.Centroids {
+	for i, centroid := range t.processed {
 		cur := centroid.Weight
 		t.cumulative[i] = prev + cur/2.0
 		prev = prev + cur
@@ -120,11 +120,11 @@ func (t *TDigest) Quantile(q float64) float64 {
 		return math.NaN()
 	}
 	if t.processed.Len() == 1 {
-		return t.processed.MeanAt(0)
+		return t.processed[0].Mean
 	}
 	index := q * t.processedWeight
-	if index < t.processed.WeightAt(0)/2.0 {
-		return t.min + 2.0*index/t.processed.WeightAt(0)*(t.processed.MeanAt(0)-t.min)
+	if index < t.processed[0].Weight/2.0 {
+		return t.min + 2.0*index/t.processed[0].Weight*(t.processed[0].Mean-t.min)
 	}
 
 	lower := sort.Search(len(t.cumulative), func(i int) bool {
@@ -134,12 +134,12 @@ func (t *TDigest) Quantile(q float64) float64 {
 	if lower+1 != len(t.cumulative) {
 		z1 := index - t.cumulative[lower-1]
 		z2 := t.cumulative[lower] - index
-		return weightedAverage(t.processed.MeanAt(lower-1), z2, t.processed.MeanAt(lower), z1)
+		return weightedAverage(t.processed[lower-1].Mean, z2, t.processed[lower].Mean, z1)
 	}
 
-	z1 := index - t.processedWeight - t.processed.WeightAt(lower-1)/2.0
-	z2 := (t.processed.WeightAt(lower-1) / 2.0) - z1
-	return weightedAverage(t.processed.MeanAt(t.processed.Len()-1), z1, t.max, z2)
+	z1 := index - t.processedWeight - t.processed[lower-1].Weight/2.0
+	z2 := (t.processed[lower-1].Weight / 2.0) - z1
+	return weightedAverage(t.processed[t.processed.Len()-1].Mean, z1, t.max, z2)
 }
 
 func (t *TDigest) CDF(x float64) float64 {
@@ -168,33 +168,33 @@ func (t *TDigest) CDF(x float64) float64 {
 	if x >= t.max {
 		return 1.0
 	}
-	m0 := t.processed.MeanAt(0)
+	m0 := t.processed[0].Mean
 	// Left Tail
 	if x <= m0 {
 		if m0-t.min > 0 {
-			return (x - t.min) / (m0 - t.min) * t.processed.WeightAt(0) / t.processedWeight / 2.0
+			return (x - t.min) / (m0 - t.min) * t.processed[0].Weight / t.processedWeight / 2.0
 		}
 		return 0.0
 	}
 	// Right Tail
-	mn := t.processed.MeanAt(t.processed.Len() - 1)
+	mn := t.processed[t.processed.Len()-1].Mean
 	if x >= mn {
 		if t.max-mn > 0.0 {
-			return 1.0 - (t.max-x)/(t.max-mn)*t.processed.WeightAt(t.processed.Len()-1)/t.processedWeight/2.0
+			return 1.0 - (t.max-x)/(t.max-mn)*t.processed[t.processed.Len()-1].Weight/t.processedWeight/2.0
 		}
 		return 1.0
 	}
 
 	upper := sort.Search(t.processed.Len(), func(i int) bool {
-		return t.processed.MeanAt(i) > x
+		return t.processed[i].Mean > x
 	})
 
-	z1 := x - t.processed.MeanAt(upper-1)
+	z1 := x - t.processed[upper-1].Mean
 	var z2 float64
 	if upper == t.processed.Len() {
 		z2 = z1
 	} else {
-		z2 = t.processed.MeanAt(upper) - x
+		z2 = t.processed[upper].Mean - x
 	}
 	return weightedAverage(t.cumulative[upper-1], z2, t.cumulative[upper], z1) / t.processedWeight
 }


### PR DESCRIPTION
This change has significant perf benefits.
```
Benchcmp results:

benchmark                       old ns/op     new ns/op     delta
BenchmarkTDigest_Add-8          303797099     210126583     -30.83%
BenchmarkTDigest_Quantile-8     379           364           -3.96%

benchmark                       old allocs     new allocs     delta
BenchmarkTDigest_Add-8          1000128        128            -99.99%
BenchmarkTDigest_Quantile-8     0              0              +0.00%

benchmark                       old bytes     new bytes     delta
BenchmarkTDigest_Add-8          33342352      1506176       -95.48%
BenchmarkTDigest_Quantile-8     0             0             +0.00%
```