### PR TITLE
fix(tdigest): update left-edge boundary logic

### DIFF
--- a/tdigest.go
+++ b/tdigest.go
@@ -123,7 +123,7 @@ func (t *TDigest) Quantile(q float64) float64 {
 		return t.processed[0].Mean
 	}
 	index := q * t.processedWeight
-	if index < t.processed[0].Weight/2.0 {
+	if index <= t.processed[0].Weight/2.0 {
 		return t.min + 2.0*index/t.processed[0].Weight*(t.processed[0].Mean-t.min)
 	}
 

--- a/tdigest_test.go
+++ b/tdigest_test.go
@@ -61,6 +61,12 @@ func TestTdigest_Quantile(t *testing.T) {
 			want:     3,
 		},
 		{
+			name:     "data in decreasing order",
+			quantile: 0.25,
+			data:     []float64{555.349107, 432.842597},
+			want:     432.842597,
+		},
+		{
 			name:     "small",
 			quantile: 0.5,
 			data:     []float64{1, 2, 3, 4, 5, 5, 4, 3, 2, 1},


### PR DESCRIPTION
This differs from the C++ version as the C++ version returns back 0.0 when running off the edge of the
arrays.  I suspect the logic in the C++ version isn't quite right either.