### PR TITLE
add Merge(), and other small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,3 @@ func main() {
 	log.Println("CDF(5) = ", td.CDF(5))
 }
 ```
-
-## TODO
-
-Only the methods for a single TDigest have been implemented.
-The methods to merge two or more existing t-digests into a single t-digest have yet to be implemented.

--- a/tdigest.go
+++ b/tdigest.go
@@ -52,9 +52,6 @@ func (t *TDigest) Reset() {
 
 // Add adds a value x with a weight w to the distribution.
 func (t *TDigest) Add(x, w float64) {
-	if math.IsNaN(x) {
-		return
-	}
 	t.AddCentroid(Centroid{Mean: x, Weight: w})
 }
 
@@ -69,7 +66,15 @@ func (t *TDigest) AddCentroidList(c CentroidList) {
 }
 
 // AddCentroid adds a single centroid.
+// Weights which are not a number or are <= 0 are ignored, as a NaN means.
 func (t *TDigest) AddCentroid(c Centroid) {
+	if math.IsNaN(c.Mean) {
+		return
+	}
+	if c.Weight <= 0 || math.IsNaN(c.Weight) || math.IsInf(c.Weight, 1) {
+		return
+	}
+
 	t.unprocessed = append(t.unprocessed, c)
 	t.unprocessedWeight += c.Weight
 

--- a/tdigest.go
+++ b/tdigest.go
@@ -66,12 +66,9 @@ func (t *TDigest) AddCentroidList(c CentroidList) {
 }
 
 // AddCentroid adds a single centroid.
-// Weights which are not a number or are <= 0 are ignored, as a NaN means.
+// Weights which are not a number or are <= 0 are ignored, as are NaN means.
 func (t *TDigest) AddCentroid(c Centroid) {
-	if math.IsNaN(c.Mean) {
-		return
-	}
-	if c.Weight <= 0 || math.IsNaN(c.Weight) || math.IsInf(c.Weight, 1) {
+	if math.IsNaN(c.Mean) || c.Weight <= 0 || math.IsNaN(c.Weight) || math.IsInf(c.Weight, 1) {
 		return
 	}
 
@@ -89,10 +86,7 @@ func (t *TDigest) AddCentroid(c Centroid) {
 // copy of the CentroidList.
 func (t *TDigest) Merge(t2 *TDigest) {
 	t2.process()
-
-	for i := range t2.processed {
-		t.AddCentroid(t2.processed[i])
-	}
+	t.AddCentroidList(t2.processed)
 }
 
 func (t *TDigest) process() {
@@ -141,6 +135,9 @@ func (t *TDigest) Centroids(cl CentroidList) CentroidList {
 
 func (t *TDigest) Count() float64 {
 	t.process()
+
+	// t.process always updates t.processedWeight to the total count of all
+	// centroids, so we don't need to re-count here.
 	return t.processedWeight
 }
 

--- a/tdigest.go
+++ b/tdigest.go
@@ -124,11 +124,7 @@ func (t *TDigest) Centroids(cl CentroidList) CentroidList {
 
 func (t *TDigest) Count() float64 {
 	t.process()
-	count := 0.0
-	for _, centroid := range t.processed {
-		count += centroid.Weight
-	}
-	return count
+	return t.processedWeight
 }
 
 func (t *TDigest) updateCumulative() {

--- a/tdigest.go
+++ b/tdigest.go
@@ -84,6 +84,17 @@ func (t *TDigest) AddCentroid(c Centroid) {
 	}
 }
 
+// Merges the supplied digest into this digest. Functionally equivalent to
+// calling t.AddCentroidList(t2.Centroids(nil)), but avoids making an extra
+// copy of the CentroidList.
+func (t *TDigest) Merge(t2 *TDigest) {
+	t2.process()
+
+	for i := range t2.processed {
+		t.AddCentroid(t2.processed[i])
+	}
+}
+
 func (t *TDigest) process() {
 	if t.unprocessed.Len() > 0 ||
 		t.processed.Len() > t.maxProcessed {
@@ -121,7 +132,8 @@ func (t *TDigest) process() {
 // Centroids returns a copy of processed centroids.
 // Useful when aggregating multiple t-digests.
 //
-// Pass in the CentroidList as the buffer to write into.
+// Centroids are appended to the passed CentroidList; if you're re-using a
+// buffer, be sure to pass cl[:0].
 func (t *TDigest) Centroids(cl CentroidList) CentroidList {
 	t.process()
 	return append(cl, t.processed...)

--- a/tdigest_test.go
+++ b/tdigest_test.go
@@ -328,6 +328,28 @@ func TestTdigest_Reset(t *testing.T) {
 	}
 }
 
+func TestTdigest_OddInputs(t *testing.T) {
+	td := tdigest.New()
+	td.Add(math.NaN(), 1)
+	td.Add(1, math.NaN())
+	td.Add(1, 0)
+	td.Add(1, -1000)
+	if td.Count() != 0 {
+		t.Error("invalid value was alloed to be added")
+	}
+
+	// Infinite values are allowed.
+	td.Add(1, 1)
+	td.Add(2, 1)
+	td.Add(math.Inf(1), 1)
+	if q := td.Quantile(0.5); q != 2 {
+		t.Errorf("expected median value 2, got %f", q)
+	}
+	if q := td.Quantile(0.9); !math.IsInf(q, 1) {
+		t.Errorf("expected median value 2, got %f", q)
+	}
+}
+
 var quantiles = []float64{0.1, 0.5, 0.9, 0.99, 0.999}
 
 func BenchmarkTDigest_Add(b *testing.B) {

--- a/tdigest_test.go
+++ b/tdigest_test.go
@@ -120,6 +120,18 @@ func TestTdigest_Count(t *testing.T) {
 			}
 		})
 	}
+
+	got := NormalDigest.Count()
+	want := float64(len(NormalData))
+	if got != want {
+		t.Errorf("unexpected count for NormalDigest, got %g want %g", got, want)
+	}
+
+	got = UniformDigest.Count()
+	want = float64(len(UniformData))
+	if got != want {
+		t.Errorf("unexpected count for UniformDigest, got %g want %g", got, want)
+	}
 }
 
 func TestTdigest_Quantile(t *testing.T) {


### PR DESCRIPTION
Added Merge(), which is no faster than existing methods of merging, but it's more convenient and avoids any allocation.

Made Count() effectively free to call.

Added more defense against invalid inputs, and tests for them.

Removed the updateCumulative() call from process(), which is a negligible speedup but avoids numerous allocations when adding a lot of values.
