### PR TITLE
feat: Expose ByteSizeForCompression function

### DIFF
--- a/tdigest.go
+++ b/tdigest.go
@@ -39,6 +39,30 @@ func NewWithCompression(c float64) *TDigest {
 	return t
 }
 
+// Calculate number of bytes needed for a tdigest of size c,
+// where c is the compression value
+func ByteSizeForCompression(comp float64) int {
+	c := int(comp)
+	// // A centroid is 2 float64s, so we need 16 bytes for each centroid
+	// float_size := 8
+	// centroid_size := 2 * float_size
+
+	// // Unprocessed and processed can grow up to length c
+	// unprocessed_size := centroid_size * c
+	// processed_size := unprocessed_size
+
+	// // the cumulative field can also be of length c, but each item is a single float64
+	// cumulative_size := float_size * c // <- this could also be unprocessed_size / 2
+
+	// return unprocessed_size + processed_size + cumulative_size
+
+	// // or, more succinctly:
+	// return float_size * c * 5
+
+	// or even more succinctly
+	return c * 40
+}
+
 // Reset resets the distribution to its initial state.
 func (t *TDigest) Reset() {
 	t.processed = t.processed[:0]


### PR DESCRIPTION
Adds the `ByteSizeForCompression` function, which returns the size needed for a digest with the provided compression value.

Helps with https://github.com/influxdata/flux/issues/3455

I've included comments to show my reasoning, but I'm not sure how much of it is appropriate to keep, given that there's a much more succinct implementation.